### PR TITLE
Fix(plgmi): Preserve original randomness and threading setups

### DIFF
--- a/plgmi/reconstruct.py
+++ b/plgmi/reconstruct.py
@@ -16,6 +16,12 @@ from models.classifiers import *
 from models.generators.resnet64 import ResNetGenerator
 from utils import save_tensor_images
 
+print(f'>> Original number of threads: {torch.get_num_threads()}')
+thread_rate = 0.25 if torch.get_num_threads() > 16 else 1
+print(f'>> Set threading rate to be {thread_rate}')
+torch.set_num_threads(int(torch.get_num_threads() * thread_rate))
+print(f'>> Current number of threads: {torch.get_num_threads()}')
+
 
 device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
 
@@ -246,7 +252,7 @@ if __name__ == "__main__":
     T = torch.nn.DataParallel(T).cuda()
     ckp_T = torch.load(path_T)
     T.load_state_dict(ckp_T['state_dict'], strict=False)
-    T = T.module # disable data parallel to ensure reproducibility
+    # T = T.module # disable data parallel to ensure reproducibility
     logger.info(f"=> Model loaded from {path_T}")
 
     # Load evaluation model
@@ -258,7 +264,7 @@ if __name__ == "__main__":
     path_E = args.eval_file
     ckp_E = torch.load(path_E)
     E.load_state_dict(ckp_E['state_dict'], strict=False)
-    E = E.module # disable data parallel to ensure reproducibility
+    # E = E.module # disable data parallel to ensure reproducibility
 
     logger.info("=> Begin attacking ...")
     aver_acc, aver_acc5, aver_var, aver_var5 = 0, 0, 0, 0

--- a/plgmi/train_cgan.py
+++ b/plgmi/train_cgan.py
@@ -17,6 +17,12 @@ from models.classifiers import *
 from models.discriminators.snresnet64 import SNResNetProjectionDiscriminator
 from models.generators.resnet64 import ResNetGenerator
 
+print(f'>> Original number of threads: {torch.get_num_threads()}')
+thread_rate = 0.25 if torch.get_num_threads() > 16 else 1
+print(f'>> Set threading rate to be {thread_rate}')
+torch.set_num_threads(int(torch.get_num_threads() * thread_rate))
+print(f'>> Current number of threads: {torch.get_num_threads()}')
+
 def set_random_seed(seed=0):
     random.seed(seed)
     np.random.seed(seed)
@@ -162,7 +168,7 @@ def main():
     target_model_path = args.ckpt_file
     target_model = torch.nn.DataParallel(target_model).cuda()
     target_model.load_state_dict(torch.load(target_model_path)['state_dict'], strict=False)
-    target_model = target_model.module # disable data parallel to ensure reproducibility
+    # target_model = target_model.module # disable data parallel to ensure reproducibility
     target_model.eval()
     print(f'=> Model loaded from {target_model_path}')
 
@@ -174,7 +180,7 @@ def main():
     evaluate_model_path = args.eval_file
     evaluate_model = torch.nn.DataParallel(evaluate_model).cuda()
     evaluate_model.load_state_dict(torch.load(evaluate_model_path)['state_dict'], strict=False)
-    evaluate_model = evaluate_model.module # disable data parallel to ensure reproducibility
+    # evaluate_model = evaluate_model.module # disable data parallel to ensure reproducibility
     evaluate_model.eval()
 
     # CUDA setting


### PR DESCRIPTION
The PLG-MI scripts created unstable results before, which causes the ASR vary significantly between identical runs. By limiting the number of threads if the core count is high and add some randomness, the code prevents resource contention and ensures that attack results are stable and reproducible.